### PR TITLE
Avoid DataLoader shared memory bus error

### DIFF
--- a/src/visual/riichi_data.py
+++ b/src/visual/riichi_data.py
@@ -5,6 +5,16 @@ from torch.utils.data import DataLoader
 from torchvision import datasets, transforms
 from riichi_dataset_loader import RiichiDatasetZarr
 
+# DataLoader workers on some systems may encounter "bus error" crashes when
+# the default shared memory strategy is used.  To avoid relying on `/dev/shm`,
+# switch to the more robust file-system based sharing strategy.
+try:
+    torch.multiprocessing.set_sharing_strategy("file_system")
+except RuntimeError:
+    # If the strategy cannot be set (e.g. unsupported backend) we simply
+    # proceed with the default behaviour.
+    pass
+
 def build_riichi_dataloader(
     root: str,
     batch_size: int,


### PR DESCRIPTION
## Summary
- use file-system sharing strategy to prevent DataLoader bus errors on limited `/dev/shm`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c434bd827c832aba93ec5d92b24ed7