### PR TITLE
Implement chunked sampler for Riichi dataloader

### DIFF
--- a/tests/test_riichi_data.py
+++ b/tests/test_riichi_data.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import torch
+from torch.utils.data import Dataset
+
+from visual.riichi_data import ChunkedRandomSampler
+
+
+class _DummyDataset(Dataset):
+    def __init__(self, length: int) -> None:
+        self.length = length
+
+    def __len__(self) -> int:
+        return self.length
+
+    def __getitem__(self, index: int):  # pragma: no cover - unused in sampler tests
+        return index
+
+
+def test_chunked_sampler_covers_all_indices() -> None:
+    dataset = _DummyDataset(103)
+    generator = torch.Generator().manual_seed(1234)
+    sampler = ChunkedRandomSampler(dataset, chunk_size=7, generator=generator)
+
+    order = list(iter(sampler))
+
+    assert len(order) == 103
+    assert len(set(order)) == 103
+    assert sorted(order) == list(range(103))
+
+
+def test_chunked_sampler_is_seed_deterministic() -> None:
+    dataset = _DummyDataset(50)
+    generator_a = torch.Generator().manual_seed(42)
+    generator_b = torch.Generator().manual_seed(42)
+
+    order_a = list(iter(ChunkedRandomSampler(dataset, chunk_size=8, generator=generator_a)))
+    order_b = list(iter(ChunkedRandomSampler(dataset, chunk_size=8, generator=generator_b)))
+
+    assert order_a == order_b
+
+
+def test_chunked_sampler_handles_empty_dataset() -> None:
+    dataset = _DummyDataset(0)
+    sampler = ChunkedRandomSampler(dataset)
+
+    assert list(iter(sampler)) == []
+    assert len(sampler) == 0
+


### PR DESCRIPTION
## Summary
- introduce a ChunkedRandomSampler that keeps only a small chunk of shuffled indices in memory at a time
- update `build_riichi_dataloader` to use the new sampler and worker settings to avoid the large one-shot permutation used previously
- add unit tests covering the sampler's determinism and coverage characteristics

## Testing
- python -m unittest discover tests *(fails: missing torch/pyyaml in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8c129d040832a8bea3fa9e425d32b